### PR TITLE
Implement cache and fail gracefully on error

### DIFF
--- a/org-yt.el
+++ b/org-yt.el
@@ -32,7 +32,7 @@
   :group 'org-yt
   :type 'string)
 
-(defcustom org-yt-cache-directory "~/.emacs.d/yt-cache"
+(defcustom org-yt-cache-directory (concat user-emacs-directory "yt-cache")
   "Directory used to cache thumbnails. Make sure it does not end in /"
   :group 'org-yt
   :type 'string

--- a/org-yt.el
+++ b/org-yt.el
@@ -131,7 +131,7 @@ This function is almost a duplicate of a part of `org-display-inline-images'."
 Use this as :image-data-fun property in `org-link-properties'.
 See `org-display-user-inline-images' for a description of :image-data-fun."
   (when (string-match org-yt-video-id-regexp link)
-    (org-yt-get-image (format "http://img.youtube.com/vi/%s/0.jpg" link))))
+    (org-yt-get-image (format "https://img.youtube.com/vi/%s/0.jpg" link))))
 
 (org-link-set-parameters org-yt-url-protocol
 			 :follow #'org-yt-follow

--- a/org-yt.el
+++ b/org-yt.el
@@ -38,6 +38,13 @@
   :type 'string
   )
 
+(defcustom org-yt-use-cache nil
+  "When not nil, maintain a cache of downloaded thumbnails"
+  :group 'org-yt
+  :type 'boolean
+  )
+
+
 
 
 (defun org-image-update-overlay (file link &optional data-p refresh)
@@ -177,9 +184,13 @@ This function is almost a duplicate of a part of `org-display-inline-images'."
 
 (defun org-yt-get-image-for-id (video-id)
   "Retrieve thumbnail for video-id. Try cache first."
-  (or (org-yt-image-in-cache video-id)
-      (org-yt-image-to-cache video-id (org-yt-get-image video-id)
-       )))
+  (if org-yt-use-cache
+      (or (org-yt-image-in-cache video-id)
+          (org-yt-image-to-cache video-id (org-yt-get-image video-id)
+                                 ))
+    (org-yt-get-image video-id)
+    )
+  )
 
 (defconst org-yt-video-id-regexp "[-_[:alnum:]]\\{10\\}[AEIMQUYcgkosw048]"
   "Regexp matching youtube video id's taken from `https://webapps.stackexchange.com/questions/54443/format-for-id-of-youtube-video'.")

--- a/org-yt.el
+++ b/org-yt.el
@@ -154,14 +154,20 @@ This function is almost a duplicate of a part of `org-display-inline-images'."
      )))
 
 (defun org-yt-image-to-cache (video-id image)
-  "Save the thumbnail to the cache."
+  "Save the thumbnail to the cache. Always returns image, even on error."
   ;; but only do if there is data
   (when (> (string-bytes image) 0)
     (condition-case err
-        (with-temp-buffer
-          (insert image)
-          (write-region (point-min) (point-max)
-                        (format "%s/%s.jpg" org-yt-cache-directory video-id)))
+        (progn
+          ;; create directory if it does not exist
+          (if (not (file-directory-p org-yt-cache-directory))
+              (make-directory org-yt-cache-directory t)
+            )
+          (with-temp-buffer
+            (insert image)
+            (write-region (point-min) (point-max)
+                          (format "%s/%s.jpg" org-yt-cache-directory video-id)))
+          )
       (error
        (message "Unable to write video thumbnail for video [%s] to cache [%s]... continuing" video-id err)
        )))

--- a/org-yt.el
+++ b/org-yt.el
@@ -33,7 +33,7 @@
   :type 'string)
 
 (defcustom org-yt-cache-directory "~/.emacs.d/yt-cache"
-  "Directory used to cache thumbnails"
+  "Directory used to cache thumbnails. Make sure it does not end in /"
   :group 'org-yt
   :type 'string
   )


### PR DESCRIPTION
1. Uses a directory to keep a cache of downloaded thumbnail
2. Before downloading a thumbnail, checks cache. if non-empty file, uses is instead
3. Otherwise download thumbnail, and save it to cache as a file
4. Makes it optional (by default, behaviour as before)
5. Makes the processing error-prone (in case there is no internet)
6. Uses https instead of http